### PR TITLE
load /etc/sysconfig/td-agent to allow user to override variables

### DIFF
--- a/redhat/td-agent.init
+++ b/redhat/td-agent.init
@@ -23,10 +23,13 @@ name="td-agent"
 prog="td-agent"
 td_agent=/usr/sbin/$prog
 
-PIDFILE=/var/run/td-agent/$prog.pid
+if [ -f /etc/sysconfig/$prog ]; then
+        . /etc/sysconfig/$prog
+fi
 
-DAEMON_ARGS=""
-TD_AGENT_ARGS="--user td-agent --group td-agent --log /var/log/td-agent/td-agent.log"
+PIDFILE=${PIDFILE-/var/run/td-agent/$prog.pid}
+DAEMON_ARGS=${DAEMON_ARGS-}
+TD_AGENT_ARGS="${TD_AGENT_ARGS---user td-agent --group td-agent --log /var/log/td-agent/td-agent.log}"
 
 if [ -n "${PIDFILE}" ]; then
 	mkdir -p $(dirname ${PIDFILE})


### PR DESCRIPTION
Hi,

I want to override TD_AGENT_ARGS to change group, but /etc/init.d/td-agent does not allow.

This fix allow /etc/init.d/td-agent to load /etc/sysconfig/td-agent if the file exists and override variables such as PIDFILE, DAEMON_ARGS and TD_AGENT_ARGS via sysconfig.
