### PR TITLE
"/etc/init.d/td-agent stop" fails stoping the daemon

### DIFF
--- a/debian/td-agent.init
+++ b/debian/td-agent.init
@@ -98,7 +98,7 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name ruby
 	RETVAL="$?"
 	[ "$RETVAL" = 2 ] && return 2
 	# Wait for children to finish too if this is a daemon that forks
@@ -123,7 +123,7 @@ do_reload() {
 	# restarting (for example, when it is sent a SIGHUP),
 	# then implement that here.
 	#
-	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name ruby
 	return 0
 }
 


### PR DESCRIPTION
I'm using td-agent 1.1.11-1 on Ubuntu Server 10.04.

"/etc/init.d/td-agent stop" often fails after a long time:

```
$ time sudo /etc/init.d/td-agent stop
 * Stopping td-agent td-agent                                       [fail]

real    0m35.053s
user    0m0.320s
sys 0m0.140s
```

This patch fixes the issue because the process name of td-agent is actually "ruby", not "td-agent".

> −n, −−name process-name
> Check for processes with the name process-name (according to /proc/pid/stat).
