### PR TITLE
Fix a typo in debian/changelog.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,7 +5,7 @@ td-agent (1.1.11-1) precise; urgency=low
   * fluent-plugin-td v0.10.13
   * fluent-plugin-mongo v0.6.11
 
- -- Kazuki Ohta <k@treasure-data.com>  Tur, 06 Dec 2012 23:24:08 +0000
+ -- Kazuki Ohta <k@treasure-data.com>  Thu, 06 Dec 2012 23:24:08 +0000
 
 td-agent (1.1.10.3-1) precise; urgency=low
 


### PR DESCRIPTION
As `parsechangelog` outputs errors, I fixed a typo in changelog.
and you can use `dch` command for updating changelog.

```
$ ./make-deb5.sh
...(omitted)...
 dpkg-genchanges -b >../td-agent_1.1.11-1_amd64.changes
parsechangelog/debian: warning:     debian/changelog(l8): couldn't parse date Tur, 06 Dec 2012 23:24:08 +0000
LINE:  -- Kazuki Ohta <k@treasure-data.com>  Tur, 06 Dec 2012 23:24:08 +0000
parsechangelog/debian: warning:     debian/changelog(l8): couldn't parse date Tur, 06 Dec 2012 23:24:08 +0000
LINE:  -- Kazuki Ohta <k@treasure-data.com>  Tur, 06 Dec 2012 23:24:08 +0000
dpkg-genchanges: binary-only upload - not including any source code
 dpkg-source --after-build td-agent-1.1.11
parsechangelog/debian: warning: td-agent-1.1.11/debian/changelog(l8): couldn't parse date Tur, 06 Dec 2012 23:24:08 +0000
```
