### PR TITLE
Changed to use runuser in daemon function.

### DIFF
--- a/redhat/td-agent.init
+++ b/redhat/td-agent.init
@@ -30,8 +30,8 @@ if [ -f /etc/sysconfig/$prog ]; then
 	. /etc/sysconfig/$prog
 fi
 PIDFILE=${PIDFILE-/var/run/td-agent/$prog.pid}
-DAEMON_ARGS=${DAEMON_ARGS-}
-TD_AGENT_ARGS="${TD_AGENT_ARGS-/usr/sbin/td-agent --user td-agent --group td-agent --log /var/log/td-agent/td-agent.log}"
+DAEMON_ARGS=${DAEMON_ARGS---user td-agent}
+TD_AGENT_ARGS="${TD_AGENT_ARGS-/usr/sbin/td-agent --group td-agent --log /var/log/td-agent/td-agent.log}"
 
 if [ -n "${PIDFILE}" ]; then
 	mkdir -p $(dirname ${PIDFILE})


### PR DESCRIPTION
Current version init-script is not applied limits.conf.

```
$ cat /etc/security/limits.d/td-agent.conf
td-agent - nofile 32768
```

Because daemon function in /etc/init.d/functions does not call runuser, call BASH by root user.

current:

```
root : init-script -> bash -> ruby -> setuid(td-agent)
```

patched:

```
root : init-script -> runuser(td-agent) ->
td-agent : bash -> ruby 
```

environment: CentOS5.9 and CentOS6.3
