### PR TITLE
debianディレクトリに含まれるlogrotateファイルがmake-rpm.sh実行時にコピーされていないためエラーになる箇所を修正

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,7 @@ install: install-recursive
 	mkdir -p $(DESTDIR)$(sysconfdir)/td-agent/prelink.conf.d
 	cp -f $(srcdir)/td-agent.prelink.conf $(DESTDIR)$(sysconfdir)/td-agent/prelink.conf.d/td-agent.conf
 	mkdir -p $(DESTDIR)$(sysconfdir)/td-agent/logrotate.d
-	cp -f $(srcdir)/debian/td-agent.logrotate $(DESTDIR)$(sysconfdir)/td-agent/logrotate.d/td-agent.logrotate
+	cp -f $(srcdir)/td-agent.logrotate $(DESTDIR)$(sysconfdir)/td-agent/logrotate.d/td-agent.logrotate
 	mkdir -p $(DESTDIR)$(sysconfdir)/td-agent/plugin
 
 dist:

--- a/make-rpm.sh
+++ b/make-rpm.sh
@@ -26,7 +26,7 @@ cp td-agent.prelink.conf $dst
 cp Makefile.am $dst
 cp autogen.sh $dst
 cp configure.in $dst
-cp -r ./debian $dst
+cp ./debian/td-agent.logrotate $dst
 tar czf $dst.tar.gz $dst
 rm -fR $dst
 


### PR DESCRIPTION
make-rpm.shにてlogrotate用のファイルをコピーする際にBUILDディレクトリにdebianディレクトリが無いためエラーになる点を修正
