### PR TITLE
Add prerequisites to `make-rpm.sh`

### DIFF
--- a/make-rpm.sh
+++ b/make-rpm.sh
@@ -11,7 +11,7 @@ if [ ! -z "$1" ]; then
 fi
 
 # install required packages
-yum install -y zlib-devel automake autoconf libtool auto-buildrequires openssl-devel
+yum install -y zlib-devel automake autoconf libtool auto-buildrequires openssl-devel libxml2-devel libxslt-devel
 
 # setup td-agent-$version.tar.gz from fluentd.git
 rm -fR fluentd


### PR DESCRIPTION
I got an error while building RPM by `make-rpm.sh` (detailed error is pasterd below).

```
$ sudo ./make-rpm.sh 60c55b23a54c822e481fa6c9ab12579da0d5bee2
```

td-agent seems to require the additional packages below:
- libxslt-devel
- libxml2-devel

I added them into `make-rpm.sh`.

```
[vagrant@local td-agent]$ sudo ./make-rpm.sh 60c55b23a54c822e481fa6c9ab12579da0d5bee2
Loaded plugins: fastestmirror, presto
Loading mirror speeds from cached hostfile
 * base: ftp.iij.ad.jp
 * extras: ftp.iij.ad.jp
 * updates: ftp.iij.ad.jp
Setting up Install Process
Package zlib-devel-1.2.3-29.el6.x86_64 already installed and latest version
Package automake-1.11.1-4.el6.noarch already installed and latest version
Package autoconf-2.63-5.1.el6.noarch already installed and latest version
Package libtool-2.2.6-15.5.el6.x86_64 already installed and latest version
No package auto-buildrequires available.
Package openssl-devel-1.0.0-27.el6_4.2.x86_64 already installed and latest version
Nothing to do
Initialized empty Git repository in /vagrant/tmp/td-agent/fluentd/.git/
remote: Counting objects: 3791, done.
remote: Compressing objects: 100% (965/965), done.
remote: Total 3791 (delta 2413), reused 3663 (delta 2294)
Receiving objects: 100% (3791/3791), 508.51 KiB | 127 KiB/s, done.
Resolving deltas: 100% (2413/2413), done.
Note: checking out '60c55b23a54c822e481fa6c9ab12579da0d5bee2'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 60c55b2... v0.10.32
/vagrant/tmp/td-agent/rpmbuild /vagrant/tmp/td-agent
エラー: ビルド依存性の失敗:
        libxslt-devel は td-agent-1.1.11-0.60c55b23a5.x86_64 に必要とされています
        libxml2-devel は td-agent-1.1.11-0.60c55b23a5.x86_64 に必要とされています
/vagrant/tmp/td-agent
```
