### PR TITLE
make-deb5.sh is broken

### DIFF
--- a/make-deb5.sh
+++ b/make-deb5.sh
@@ -17,6 +17,7 @@ cp -r debian $dst
 cp td-agent.conf $dst
 cp td-agent.prelink.conf $dst
 cp Makefile.am $dst
+cp td-agent.logrotate $dst
 cp autogen.sh $dst
 cp configure.in $dst
 tar czf $dst.tar.gz $dst


### PR DESCRIPTION
Since td-agent.logrotate is not copied to build directory,
the dpkg-buildpackage process will end up with a "cannot stat './td-agent.logrotate'..." error.
