### PR TITLE
Add lsb-release to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
   autotools-dev,
   libssl-dev,
   wget,
+  lsb-release,
   git-core,
   libxslt1.1,
   libxslt1-dev,


### PR DESCRIPTION
If lsb-release has not been installed, build doesn't work correctly.
(https://github.com/treasure-data/td-agent/blob/master/debian/rules#L9)

I think we should add lsb-release to build-depends.
