### PR TITLE
add configtest td-agent.init

### DIFF
--- a/redhat/td-agent.init
+++ b/redhat/td-agent.init
@@ -73,8 +73,21 @@ stop() {
 }
 
 restart() {
+	configtest || return $?
 	stop
 	start
+}
+
+reload() {
+	configtest || return $?
+	echo -n "Reloading $name: "
+	killproc $td_agent -HUP
+	RETVAL=$?
+	echo
+}
+
+configtest() {
+	/usr/sbin/td-agent --dry-run -q
 }
 
 case "$1" in
@@ -85,20 +98,22 @@ case "$1" in
 	stop
 	;;
     restart)
-    	restart
+	restart
 	;;
     reload)
-	killproc $td_agent -HUP
+	reload
 	;;
     condrestart)
 	[ -f /var/lock/subsys/$prog ] && restart || :
 	;;
-
+    configtest)
+        configtest
+        ;;
     status)
 	status -p $PIDFILE 'td-agent'
 	;;
     *)
-	echo "Usage: $prog {start|stop|reload|restart|condrestart|status}"
+	echo "Usage: $prog {start|stop|reload|restart|condrestart|status|configtest}"
 	exit 1
 	;;
 esac


### PR DESCRIPTION
Hi,

I commited configtest at redhat initscript.
Please check it.
- reference : [Red Hat Nginx Init Script - nginx](http://wiki.nginx.org/RedHatNginxInitScript)

---

```
# /etc/init.d/td-agent
Usage: td-agent {start|stop|reload|restart|condrestart|status|configtest}
#
```
- td-agent.conf

```
<source>
  type forward
  port 24224
</source>

<match **>
  type file
  path /tmp/td-agent-unmatch
</match>
```
### start

```
# /etc/init.d/td-agent start
Starting td-agent:                                         [  OK  ]
#
```
### reload

```
# /etc/init.d/td-agent reload
Reloading td-agent:                                        [  OK  ]
#
```
### restart

```
# /etc/init.d/td-agent restart
Shutting down td-agent:                                    [  OK  ]
Starting td-agent:                                         [  OK  ]
#
```

---

chage td-agent.conf

```
<source>
  type forward
  port 24224
</source>

<match **>
  type file
  path /tmp/td-agent-unmatch
</matchh> # typo
```
### reload

Fail before it is reloaded.

```
# /etc/init.d/td-agent status
td-agent (pid  2495) is running...
#
# /etc/init.d/td-agent reload
2013-08-02 17:55:43 +0900 [error]: Dry run failed: parse error at td-agent.conf line 9
#
# /etc/init.d/td-agent status
td-agent (pid  2495) is running...
#
```
### restart

Fail before it is restarted.

```
# /etc/init.d/td-agent status
td-agent (pid  2495) is running...
#
# /etc/init.d/td-agent restart
2013-08-02 17:56:27 +0900 [error]: Dry run failed: parse error at td-agent.conf line 9
#
# /etc/init.d/td-agent status
td-agent (pid  2495) is running...
#
```
