### PR TITLE
Fixes for user-locally-built rpms of td-agent

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,12 @@ plugins:
 		fi; \
 	done
 
+extplugin:
+	if [ ! -f "$(srcdir)/plugins/$(EXTGEM)" ]; then \
+	    wget "http://rubygems.org/downloads/$(EXTGEM)" -O "$(srcdir)/plugins/$(EXTGEM)"; \
+	fi
+
+# duplicate of PLUGINS and $(srcdir)/plugins/*.gem depends on install order of nokogiri and aws-sdk (and others)
 install: install-recursive
 	for gem in $(srcdir)/deps/*.gem; do \
 		RUBYLIB="$(DEST_RUBY_LIBDIR)/1.9.1:$(DEST_RUBY_LIBDIR)/1.9.1/$(shell $(DEST_RUBY) --version | sed 's/.*\[\(.*\)\]/\1/')" \
@@ -60,15 +66,22 @@ install: install-recursive
 		RUBYLIB="$(DEST_RUBY_LIBDIR)/1.9.1:$(DEST_RUBY_LIBDIR)/1.9.1/$(shell $(DEST_RUBY) --version | sed 's/.*\[\(.*\)\]/\1/')" \
 			$(DEST_GEM) install --no-rdoc --no-ri "$$gem"; \
 	done
-	for gem in $(PLUGINS); do \
+	for gemname in $(PLUGINS); do \
 		RUBYLIB="$(DEST_RUBY_LIBDIR)/1.9.1:$(DEST_RUBY_LIBDIR)/1.9.1/$(shell $(DEST_RUBY) --version | sed 's/.*\[\(.*\)\]/\1/')" \
-			$(DEST_GEM) install --no-rdoc --no-ri "$(srcdir)/plugins/$$gem"; \
+			$(DEST_GEM) install --no-rdoc --no-ri "$(srcdir)/plugins/$$gemname"; \
+	done
+	for gem in $(srcdir)/plugins/*.gem; do \
+		RUBYLIB="$(DEST_RUBY_LIBDIR)/1.9.1:$(DEST_RUBY_LIBDIR)/1.9.1/$(shell $(DEST_RUBY) --version | sed 's/.*\[\(.*\)\]/\1/')" \
+			$(DEST_GEM) install --no-rdoc --no-ri "$$gem"; \
 	done
 	rm -fR $(DEST_RUBY_LIBDIR)/gems/1.9.1/gems/bson-*/bin/b2json
 	rm -fR $(DEST_RUBY_LIBDIR)/gems/1.9.1/gems/bson-*/bin/j2bson
 	rm -fR $(DEST_RUBY_LIBDIR)/gems/1.9.1/gems/td-*/dist/resources/pkg/td
 	mkdir -p $(DESTDIR)$(sysconfdir)/td-agent
 	cp -f $(srcdir)/td-agent.conf $(DESTDIR)$(sysconfdir)/td-agent/td-agent.conf.tmpl
+	if [ -f "$(srcdir)/td-agent.conf.custom" ]; then \
+	    cp -f $(srcdir)/td-agent.conf.custom $(DESTDIR)$(sysconfdir)/td-agent/td-agent.conf; \
+	fi
 	mkdir -p $(DESTDIR)$(sysconfdir)/td-agent/prelink.conf.d
 	cp -f $(srcdir)/td-agent.prelink.conf $(DESTDIR)$(sysconfdir)/td-agent/prelink.conf.d/td-agent.conf
 	mkdir -p $(DESTDIR)$(sysconfdir)/td-agent/logrotate.d

--- a/make-rpm.sh
+++ b/make-rpm.sh
@@ -17,16 +17,24 @@ yum install -y wget make rpmbuild gcc gcc-c++ readline-devel openssl-devel libxm
 rm -fR fluentd
 git clone git://github.com/fluent/fluentd.git
 cd fluentd
-git checkout $rev
+git checkout -b $rev # -b: don't show message to suggest 'you are not anywhere' of git
 cd ..
 rm -fR $dst
 mv fluentd $dst
 cp td-agent.conf $dst
+if [ -f redhat/td-agent.conf.custom ]; then
+  cp redhat/td-agent.conf.custom $dst
+fi
 cp td-agent.prelink.conf $dst
 cp Makefile.am $dst
 cp autogen.sh $dst
 cp configure.in $dst
 cp ./td-agent.logrotate $dst
+# locate pre-downloaded gems
+if [ -d plugin_gems ]; then
+  mkdir -p $dst/plugins
+  cp plugin_gems/*.gem $dst/plugins
+fi
 tar czf $dst.tar.gz $dst
 rm -fR $dst
 
@@ -44,6 +52,10 @@ cp ../redhat/td-agent.spec SPECS
 mv ../$dst.tar.gz SOURCES
 # locate init.d script
 cp ../redhat/td-agent.init SOURCES
+# locate customized configuration file
+if [ -f ../redhat/td-agent.conf.custom ]; then
+  cp ../redhat/td-agent.conf.custom SOURCES
+fi
 # build
 if [ -z "$rpm_dist" ]; then
   my_rpmbuild -v -ba --clean SPECS/td-agent.spec

--- a/redhat/td-agent.spec
+++ b/redhat/td-agent.spec
@@ -9,6 +9,7 @@ Vendor: Treasure Data, Inc.
 URL: http://treasure-data.com/
 Source: %{name}-%{version}.tar.gz
 Source1: %{name}.init
+# Source2: %{name}.conf.custom
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 
 Requires: /usr/sbin/useradd /usr/sbin/groupadd
@@ -36,7 +37,10 @@ BuildRequires: gcc gcc-c++ pkgconfig libtool openssl-devel readline-devel libxsl
 ./autogen.sh
 
 %configure
+make plugins
 make %{?_smp_mflags}
+# make extplugin EXTGEM=fluent-plugin-ping-message-0.1.0.gem
+# make extplugin EXTGEM=...
 
 %install
 # cleanup first
@@ -118,11 +122,14 @@ fi
 
 %files
 %defattr(-,root,root)
+%config(noreplace,missingok) %{_sysconfdir}/td-agent/td-agent.conf
 /usr/bin/td
 /usr/sbin/td-agent
 /usr/%{_lib}/fluent
-/etc/td-agent
+/etc/td-agent/td-agent.conf.tmpl
 /etc/init.d/td-agent
+/etc/td-agent/logrotate.d/td-agent.logrotate
+/etc/td-agent/prelink.conf.d/td-agent.conf
 /var/log/td-agent
 
 %changelog


### PR DESCRIPTION
Fixes for rpm specs and Makefiles to be able to accept user-defined customized configuration files and plugin lists.
- customized config file (td-agent.conf) acceptable as redhat/td-agent.conf.custom
  - "td-agent.conf" (renamed as td-agent.conf.tmpl later) already used
  - current "td-agent.conf" should be located in share directory, but such that change breaks compatibility of Makefile
- customized pre-installed plugin list as lines of %configure
  - and its receiver new Makefile task
- pre-downloaded gemfile directory (plugin_gems)
  - rubygems.org mirrors returns 503 for many-frequently-requests
  - 1 or 2 additional gems from current default list makes many of 503 errors
