### PR TITLE
Set ulimits in init.d script with recommended setting.

### DIFF
--- a/debian/td-agent.init
+++ b/debian/td-agent.init
@@ -71,9 +71,9 @@ fi
 #
 do_start()
 {
-	# 2012/07/23 Kazuki Ohta <k@treasure-data.com>
 	# Set Max number of file descriptors for the safety sake
-	ulimit -n 8192
+	# see http://docs.fluentd.org/en/articles/before-install
+	ulimit -n 65536
 
 	# Return
 	#   0 if daemon has been started

--- a/redhat/td-agent.init
+++ b/redhat/td-agent.init
@@ -51,6 +51,9 @@ fi
 RETVAL=0
 
 start() {
+	# Set Max number of file descriptors for the safety sake
+	# see http://docs.fluentd.org/en/articles/before-install
+	ulimit -n 65536
 	echo -n "Starting $name: "
 	daemon --pidfile=$PIDFILE $DAEMON_ARGS $td_agent "$TD_AGENT_ARGS"
 	RETVAL=$?


### PR DESCRIPTION
Hi @repeatedly 
It has been recommended to raise ulimit in [official document](http://docs.fluentd.org/en/articles/before-install). But, it does not set in init.d script.
So, It would be better to set `ulimit -n 65536` in init script.

Note: I have implemented like mongoDB does.
- https://github.com/mongodb/mongo/blob/master/rpm/init.d-mongod
- https://github.com/mongodb/mongo/blob/master/debian/init.d
