### PR TITLE
Package is uninstallable.

### DIFF
--- a/debian/td-agent.postrm
+++ b/debian/td-agent.postrm
@@ -3,10 +3,13 @@
 set -e
 
 if [ "$1" = "purge" ]; then
-        rm -f /etc/td-agent/*
-        dpkg-statoverride --remove /etc/td-agent
+        rm -f /etc/default/td-agent
+        rm -f /etc/td-agent/td-agent.conf
+	dpkg-statoverride --list /var/run/td-agent > /dev/null && \
+		dpkg-statoverride --remove /etc/td-agent
 	rm -f /var/run/td-agent/*
-        dpkg-statoverride --remove /var/run/td-agent
+	dpkg-statoverride --list /var/run/td-agent > /dev/null && \
+		dpkg-statoverride --remove /var/run/td-agent
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
When puring td-agent package, I get error and uninstall was aborted.

```
root@tempest:/# dpkg --purge td-agent
(Reading database ... 17638 files and directories currently installed.)
Removing td-agent ...
************************************
All rc.d operations denied by policy
************************************
invoke-rc.d: policy-rc.d denied execution of stop.
Purging configuration files for td-agent ...
rm: cannot remove `/etc/td-agent/logrotate.d': Is a directory
rm: cannot remove `/etc/td-agent/prelink.conf.d': Is a directory
dpkg: error processing td-agent (--purge):
 subprocess installed post-removal script returned error exit status 1
Errors were encountered while processing:
 td-agent
```

Because directory /etc/td-agent has sub-directory.

```
root@tempest:/# find /etc/td-agent/
/etc/td-agent/
/etc/td-agent/prelink.conf.d
/etc/td-agent/prelink.conf.d/td-agent.conf
/etc/td-agent/logrotate.d
/etc/td-agent/logrotate.d/td-agent.logrotate
/etc/td-agent/plugin
/etc/td-agent/td-agent.conf.tmpl
/etc/td-agent/td-agent.conf
```

This patch fix the problem, and also remove remaining file
added by package (/etc/default/td-agent.conf).
