### PR TITLE
Propose to cleanup package dependency (remove hard-coded and add missing)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,8 +31,6 @@ Depends:
   ${shlibs:Depends},
   ${misc:Depends},
   ${dist:Depends},
-  libssl0.9.8,
-  libxslt1.1,
-  libxml2
+  adduser
 Recommends: ntp
 Description: A data collector agent for Treasure Data

--- a/debian/rules
+++ b/debian/rules
@@ -6,8 +6,6 @@
 # dh-make output file, you may use that output file without restriction.
 # This special exception was added by Craig Small in version 0.37 of dh-make.
 
-SUBSTVARS = -Vdist:Depends="$(shell (lsb_release -a 2>/dev/null | grep -q 'Ubuntu\|squeeze') && echo libyaml-0-2 || echo libyaml-0-1)"
-
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
@@ -25,5 +23,5 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 
-override_dh_gencontrol:
-	dh_gencontrol -- $(SUBSTVARS)
+override_dh_shlibdeps:
+		dh_shlibdeps -l'/usr/lib*/fluent/ruby/bin:/usr/lib*/fluent/ruby/lib/ruby/1.9.1/*-linux:/usr/lib*/fluent/ruby/lib/ruby/gems/1.9.1/gems/*/ext'


### PR DESCRIPTION
Hello,

I found hard-coded dependency cause problem when I built package for Debian wheezy.
I suggest to remove all lib\* depenency and use dh_shlibdeps that generate library depends automatically.

In addition, I add adduser to depends on this patch because i get following error when installing the package into minimal environment.

```
Setting up td-agent (1.1.20-1.1) ...
/var/lib/dpkg/info/td-agent.postinst: 9: /var/lib/dpkg/info/td-agent.postinst: adduser: not found
dpkg: error processing td-agent (--configure):
 subprocess installed post-installation script returned error exit status 127
Errors were encountered while processing:
 td-agent
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
