### PR TITLE
Added PRIVBIND to permit configurations requiring reserved ports (< 1024...

### DIFF
--- a/debian/td-agent.init
+++ b/debian/td-agent.init
@@ -29,6 +29,11 @@ DAEMON_ARGS="/usr/sbin/td-agent $DAEMON_ARGS --daemon $PIDFILE --log /var/log/td
 SCRIPTNAME=/etc/init.d/$NAME
 START_STOP_DAEMON_ARGS=""
 
+# Uncomment if the configuration requires the use of local reserved ports (<1024).
+# You may need to install privbind (e.g.: On Ubuntu, sudo apt-get install privbind).
+# PRIVBIND="/usr/sbin/privbind -u ${USER}"
+PRIVBIND=""
+
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
 
@@ -79,10 +84,10 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+	${PRIVBIND} start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
 	${START_STOP_DAEMON_ARGS} --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
+	${PRIVBIND} start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
 	${START_STOP_DAEMON_ARGS} -- $DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready


### PR DESCRIPTION
I added the use of <a href="http://www.linuxcertif.com/man/1/privbind/">privbind</a> to permit configurations that require the use of reserved ports (< 1024).  privbind allows non-root users to open reserved ports by escalating privilege to ONLY open reserved ports - nothing else (unlike seteuid(root)).
- jss

Ref:
http://www.linuxcertif.com/man/1/privbind/
