### PR TITLE
Add flush buffer function for initscript

### DIFF
--- a/debian/td-agent.init
+++ b/debian/td-agent.init
@@ -129,6 +129,14 @@ do_reload() {
 	return 0
 }
 
+#
+# Function that sends a USR1 Signal to the daemon/service
+#
+do_flush() {
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE --name ruby
+	return 0
+}
+
 do_configtest() {
 	eval "$DAEMON_ARGS --user ${USER} --group ${GROUP} --dry-run -q"
 }
@@ -185,12 +193,14 @@ case "$1" in
 		;;
 	esac
 	;;
+  flush)
+	do_flush
+	;;
   configtest)
 	do_configtest
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|configtest}" >&2
+	echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload|flush|configtest|status}" >&2
 	exit 3
 	;;
 esac

--- a/redhat/td-agent.init
+++ b/redhat/td-agent.init
@@ -123,6 +123,13 @@ reload() {
 	echo
 }
 
+flush() {
+	echo -n "Flushing buffer $name: "
+	killproc $td_agent -USR1
+	RETVAL=$?
+	echo
+}
+
 configtest() {
 	eval "$TD_AGENT_ARGS $DAEMON_ARGS --dry-run -q"
 }
@@ -140,6 +147,9 @@ case "$1" in
     reload)
 	reload
 	;;
+    flush)
+	flush
+	;;
     condrestart)
 	[ -f /var/lock/subsys/$prog ] && restart || :
 	;;
@@ -150,7 +160,7 @@ case "$1" in
 	status -p $PIDFILE 'td-agent'
 	;;
     *)
-	echo "Usage: $prog {start|stop|reload|restart|condrestart|status|configtest}"
+	echo "Usage: $prog {start|stop|restart|reload|flush|condrestart|configtest|status}"
 	exit 1
 	;;
 esac


### PR DESCRIPTION
Add USR1 Signal function to force flushing buffered events.
It could very useful for system failure troubleshooting to re-send buffer immidiately.
## usage

```
$ sudo service td-agent flush
```

related issue : https://github.com/treasure-data/omnibus-td-agent/pull/9
