### PR TITLE
Enable `reload` in init script for Debian/Ubuntu

### DIFF
--- a/debian/td-agent.init
+++ b/debian/td-agent.init
@@ -153,15 +153,15 @@ case "$1" in
   status)
        status_of_proc "$DAEMON" ruby && exit 0 || exit $?
        ;;
-  #reload|force-reload)
+  reload|force-reload)
 	#
 	# If do_reload() is not implemented then leave this commented out
 	# and leave 'force-reload' as an alias for 'restart'.
 	#
-	#log_daemon_msg "Reloading $DESC" "$NAME"
-	#do_reload
-	#log_end_msg $?
-	#;;
+	log_daemon_msg "Reloading $DESC" "$NAME"
+	do_reload
+	log_end_msg $?
+	;;
   restart|force-reload)
 	#
 	# If the "reload" option is implemented then remove the


### PR DESCRIPTION
On Debian/Ubuntu, init script doesn't respond to `reload`. It should be reloadable as same as on RedHat.

This is as same fix as treasure-data/omnibus-td-agent#20.